### PR TITLE
Disable link-local addressing completely to address issue on radio port 2

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -8,7 +8,7 @@ on:
     tags: 
       - '*'
   pull_request:
-    branches: [ master ]
+    branches: [ master, arm64, gloworm-arm64 ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/stage2/02-net-tweaks/00-patches/01-noipv4ll.diff
+++ b/stage2/02-net-tweaks/00-patches/01-noipv4ll.diff
@@ -1,0 +1,12 @@
+Index: jessie-stage2/rootfs/etc/dhcpcd.conf
+===================================================================
+--- jessie-stage2.orig/rootfs/etc/dhcpcd.conf
++++ jessie-stage2/rootfs/etc/dhcpcd.conf
+@@ -57,3 +57,7 @@
+ # fallback to static profile on eth0
+ #interface eth0
+ #fallback static_eth0
++
++# Disable link-local addressing completely
++# This seems to cause issues when DHCP times out (?) on the FRC radio
++noipv4ll


### PR DESCRIPTION
This is our current theory for the issues on CM3 introduced after we switched to the 64-bit image. We will need someone to test. Another option that I'd like to explore more in the future is using the static IP fallback to make it easy for teams to debug networking issues; we could probably fallback to something like 10.99.99.42.