### PR TITLE
Update Java and Libcamera Packages

### DIFF
--- a/stage2/01-sys-tweaks/00-packages
+++ b/stage2/01-sys-tweaks/00-packages
@@ -33,5 +33,5 @@ udisks2
 unzip zip p7zip-full
 file
 pigpiod pigpio
-openjdk-11-jdk-headless
+openjdk-17-jdk-headless
 libtbb2

--- a/stage2/01-sys-tweaks/00-packages-nr
+++ b/stage2/01-sys-tweaks/00-packages-nr
@@ -1,4 +1,4 @@
 cifs-utils
-libcamera-apps-lite
+rpicam-apps-lite
 mkvtoolnix
 python3-picamera2


### PR DESCRIPTION
Update the naming of libcamera-apps-lite to rpicamera-apps-lite.
Update to openjdk 17